### PR TITLE
Added OpenGL and GLUT dependencies to example-sdl

### DIFF
--- a/example-sdl/CMakeLists.txt
+++ b/example-sdl/CMakeLists.txt
@@ -1,7 +1,9 @@
 find_package(SDL)
+find_package(OpenGL)
+find_package(GLUT)
 
 if(SDL_FOUND)
-	include_directories(../src ${SDL_INCLUDE_DIR})
+	include_directories(../src ${SDL_INCLUDE_DIR} ${OPENGL_INCLUDE_DIR} ${GLUT_INCLUDE_DIRS})
 	add_executable(example-sdl sdl.c)
-	target_link_libraries(example-sdl wiiuse ${SDL_LIBRARY})
+	target_link_libraries(example-sdl wiiuse ${SDL_LIBRARY} ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES})
 endif()


### PR DESCRIPTION
This fixes a bug wherein example-sdl wasn't being linked against OpenGL and GLUT libraries (and therefore failing to build).
