### PR TITLE
Change the links for the original project.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -300,8 +300,7 @@ Other Links
 - Thread about MotionPlus: <http://forum.wiibrew.org/read.php?11,32585,32922>
 
 Original project:
-
-- <http://wiiuse.net/>
-- <http://wiiuse.sourceforge.net/>
-- <http://sourceforge.net/projects/wiiuse/>
-
+- SourceForge page: <http://sourceforge.net/projects/wiiuse/>
+- Archived pages of the original project:
+  - http://web.archive.org/web/*/http://wiiuse.net/
+  - http://web.archive.org/web/*/http://wiiuse.sourceforge.net/


### PR DESCRIPTION
wiiuse.net's domain has expired and wiise.sf.net just says "Error."
