### PR TITLE
Fix file descriptor leak in wiiuse_os_find on Linux.

### DIFF
--- a/src/os_nix.c
+++ b/src/os_nix.c
@@ -92,6 +92,7 @@ int wiiuse_os_find(struct wiimote_t** wm, int max_wiimotes, int timeout) {
 	found_devices = hci_inquiry(device_id, timeout, 128, NULL, &scan_info, IREQ_CACHE_FLUSH);
 	if (found_devices < 0) {
 		perror("hci_inquiry");
+		close(device_sock);
 		return 0;
 	}
 


### PR DESCRIPTION
When a VRPN server with a WiiMote device runs for a few weeks, it eventually stops working and emits the following message coming from wiiuse:

hci_get_route: Too many open files

I suspect this is because of not closing the device socket when hci_inquiry() fails.
