### PR TITLE
Emit a disconnect event again.

### DIFF
--- a/src/events.c
+++ b/src/events.c
@@ -481,7 +481,7 @@ static void event_status(struct wiimote_t* wm, byte* msg) {
 	struct data_req_t* req = wm->data_req;
 
 	/* initial handshake is not finished yet, ignore this */
-	if (WIIMOTE_IS_SET(wm, WIIMOTE_STATE_HANDSHAKE)) {
+	if (WIIMOTE_IS_SET(wm, WIIMOTE_STATE_HANDSHAKE) || !msg) {
 		return;
 	}
 

--- a/src/os_nix.c
+++ b/src/os_nix.c
@@ -31,6 +31,7 @@
  *	@brief Handles device I/O for *nix.
  */
 
+#include "wiiuse_internal.h"           /* for WM_RPT_CTRL_STATUS */
 #include "io.h"
 #include "events.h"
 #include "os.h"
@@ -304,6 +305,13 @@ int wiiuse_os_poll(struct wiimote_t** wm, int wiimotes) {
 				/* propagate the event */
 				propagate_event(wm[i], read_buffer[0], read_buffer + 1);
 				evnt += (wm[i]->event != WIIUSE_NONE);
+			} else if (!WIIMOTE_IS_CONNECTED(wm[i])) {
+				/* freshly disconnected */
+				wm[i]->event = (r==0) ? WIIUSE_DISCONNECT : WIIUSE_UNEXPECTED_DISCONNECT;
+				evnt++;
+				/* propagate the event:
+				   Emit a controller-status type event. */
+				propagate_event(wm[i], WM_RPT_CTRL_STATUS, 0);
 			}
 		} else {
 			/* send out any waiting writes */


### PR DESCRIPTION
Fixes a regression (#48) that prevented disconnect events from being sent.

I "hijacked" the event_status() method by setting the WM_RPT_CTRL_STATUS event type and using a NULL message. This solution should be reasonably clean...
