### PR TITLE
Quick fix for RVL-CNT-01-TR on Mac

### DIFF
--- a/src/motion_plus.c
+++ b/src/motion_plus.c
@@ -60,6 +60,7 @@ void wiiuse_probe_motion_plus(struct wiimote_t *wm) {
 	id = from_big_endian_uint32_t(buf + 2);
 
 	if (id != EXP_ID_CODE_INACTIVE_MOTION_PLUS &&
+	        id != EXP_ID_CODE_INACTIVE_MOTION_PLUS_BUILTIN &&
 	        id != EXP_ID_CODE_NLA_MOTION_PLUS &&
 	        id != EXP_ID_CODE_NLA_MOTION_PLUS_NUNCHUK &&
 	        id != EXP_ID_CODE_NLA_MOTION_PLUS_CLASSIC) {

--- a/src/os_mac/os_mac_find.m
+++ b/src/os_mac/os_mac_find.m
@@ -113,7 +113,7 @@
 	// refine search & set timeout
 	[inquiry setSearchCriteria:kBluetoothServiceClassMajorAny
 			  majorDeviceClass:WM_DEV_MAJOR_CLASS
-			  minorDeviceClass:WM_DEV_MINOR_CLASS];
+			  minorDeviceClass:kBluetoothDeviceClassMinorAny];
 	[inquiry setUpdateNewDeviceNames: NO];
 	if(timeout > 0)
 		[inquiry setInquiryLength:timeout];

--- a/src/wiiuse_internal.h
+++ b/src/wiiuse_internal.h
@@ -216,10 +216,11 @@
 #define EXP_ID_CODE_MOTION_PLUS_CLASSIC     0xA4200705 /** Motion Plus ID in Classic control. passthrough */
 
 /* decrypted M+ codes at 0x04A600FA */
-#define EXP_ID_CODE_INACTIVE_MOTION_PLUS        0xA6200005 /** Inactive Motion Plus ID */
-#define EXP_ID_CODE_NLA_MOTION_PLUS             0xA6200405 /** No longer active Motion Plus ID */
-#define EXP_ID_CODE_NLA_MOTION_PLUS_NUNCHUK     0xA6200505 /** No longer active Motion Plus ID in Nunchuck passthrough mode */
-#define EXP_ID_CODE_NLA_MOTION_PLUS_CLASSIC     0xA6200705 /** No longer active Motion Plus ID in Classic control. passthrough */
+#define EXP_ID_CODE_INACTIVE_MOTION_PLUS          0xA6200005 /** Inactive Motion Plus ID */
+#define EXP_ID_CODE_INACTIVE_MOTION_PLUS_BUILTIN  0xA4200005 /** Inactive Motion Plus ID in Wii Remote Plus */
+#define EXP_ID_CODE_NLA_MOTION_PLUS               0xA6200405 /** No longer active Motion Plus ID */
+#define EXP_ID_CODE_NLA_MOTION_PLUS_NUNCHUK       0xA6200505 /** No longer active Motion Plus ID in Nunchuck passthrough mode */
+#define EXP_ID_CODE_NLA_MOTION_PLUS_CLASSIC       0xA6200705 /** No longer active Motion Plus ID in Classic control. passthrough */
 
 #define EXP_HANDSHAKE_LEN					224
 


### PR DESCRIPTION
1) It wasn't finding the device because the minor class seems to have
changed from kBluetoothDeviceClassMinorPeripheral2Joystick (0x01) to
kBluetoothDeviceClassMinorPeripheral2Gamepad (0x02).

2) It couldn't detect the built in motion plus because the exp id was
different.
