### PR TITLE
Look for cmake modules in current source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ option(CPACK_MONOLITHIC_INSTALL "Only produce a single component installer, rath
 ###
 
 # Locally-developed modules dist'ed with this app - always have this first.
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(UseBackportedModules)
 include(DoxygenTargets)
 


### PR DESCRIPTION
When used as a subproject, the source directory is not the same as
wiiuse's source directory so it won't find the cmake folder.
