### PR TITLE
Fixed Wiimote -TR under Windows. To communicate with the Wiimote unde…

### DIFF
--- a/src/os_win.c
+++ b/src/os_win.c
@@ -342,8 +342,9 @@ int wiiuse_os_write(struct wiimote_t *wm, byte report_type, byte *buf, int len)
         return 0;
     }
 
+	/* Windows should always use WriteFile instead of HidD_SetOutputReport to communicate -> data pipe instead of control pipe*/
     case WIIUSE_STACK_MS:
-        return HidD_SetOutputReport(wm->dev_handle, write_buffer, len + 1);
+        return WriteFile(wm->dev_handle, write_buffer, 22, &bytes, &wm->hid_overlap);
 
     case WIIUSE_STACK_BLUESOLEIL:
         return WriteFile(wm->dev_handle, write_buffer, 22, &bytes, &wm->hid_overlap);


### PR DESCRIPTION
Windows WriteFile instead of HidD_SetOutputReport should be used regardless of bluetooth stack type. See: https://docs.microsoft.com/en-us/windows-hardware/drivers/hid/sending-hid-reports-by-user-mode-applications