### PR TITLE
Silence CMake errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # http://academic.cleardefinition.com/
 # Iowa State University HCI Graduate Program/VRAC
 
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 3.0.0)
 
 # Set package properties
 project(WiiUse)

--- a/example-sdl/CMakeLists.txt
+++ b/example-sdl/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(OpenGL_GL_PREFERENCE LEGACY)
 find_package(SDL)
 find_package(OpenGL)
 find_package(GLUT)


### PR DESCRIPTION
Bumps CMake requirement to 3.0.0 (released in 2014)
Set OpenGL to LEGACY to silence warning.