### PR TITLE
CI: split build between Linux and macOS and limit runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,30 +1,51 @@
 name: CI
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+  release:
+    types:
+      - created
+
 jobs:
-  build:
+  build-linux:
     strategy:
       matrix:
-        # os: [ubuntu-latest, macos-latest, windows-latest]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest ] # More distributions can be added in the future
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2
-      - name: Dependencies (Linux)
-        if: matrix.os == 'ubuntu-latest'
+      - name: Install dependencies
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'debian-latest'
         run: |
           sudo apt-get update
           sudo apt-get -y install cmake libbluetooth-dev libsdl-dev freeglut3-dev
-      - name: Dependencies (MacOS)
-        if: matrix.os == 'macOS-latest'
-        run: |
-          brew update
-          brew ls --versions cmake && brew upgrade cmake || brew install cmake
       - name: Build (shared lib)
         run: | 
           cmake -B build -DBUILD_SHARED_LIBS=TRUE
-          make -C build
+          cmake --build build
       - name: Build (static lib)
         run: |
           cmake -B build
-          make -C build
+          cmake --build build
+
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          brew update
+          brew install cmake freeglut sdl
+      - name: Build (shared lib)
+        run: | 
+          cmake -B build -DBUILD_SHARED_LIBS=TRUE
+          cmake --build build
+      - name: Build (static lib)
+        run: |
+          cmake -B build
+          cmake --build build
+

--- a/example-sdl/CMakeLists.txt
+++ b/example-sdl/CMakeLists.txt
@@ -12,7 +12,11 @@ if(SDL_FOUND AND OPENGL_FOUND AND GLUT_FOUND)
 		add_executable(wiiuseexample-sdl sdl.c)
 	endif()
 
-	target_link_libraries(wiiuseexample-sdl wiiuse ${SDL_LIBRARY} ${OPENGL_LIBRARIES} ${GLUT_LIBRARIES})
+	target_link_libraries(wiiuseexample-sdl
+		wiiuse
+		SDL::SDL
+		OpenGL::GLU
+		GLUT::GLUT)
 
 	if(INSTALL_EXAMPLES)
 		install(TARGETS wiiuseexample-sdl


### PR DESCRIPTION
Only run CI on pushes to the master branch (previously it would run CI twice on PR's due to executing on pushes to any branch), changes in pull-requests and any new releases.

Also I noticed macOS didn't build the examples due to missing deps. I changed that and it revealed a compilation error (which didn't happen on Linux), so I'm guessing no one has built the examples for a while on that platform. I fixed the compilation error.