### PR TITLE
sdl example event processing

### DIFF
--- a/example-sdl/sdl.c
+++ b/example-sdl/sdl.c
@@ -440,7 +440,7 @@ int WINAPI WinMain(HINSTANCE hInstance,	HINSTANCE hPrevInstance, LPSTR lpCmdLine
 			}
 		}
 
-		if (wiiuse_poll(wiimotes, MAX_WIIMOTES)) {
+		while(wiiuse_poll(wiimotes, MAX_WIIMOTES)) {
 			/*
 			 *	This happens if something happened on any wiimote.
 			 *	So go through each one and check if anything happened.


### PR DESCRIPTION
I replaced the condition for polling events (wiiuse_poll) with a while loop. This allows to process events more quickly when there is a lot of them (we can see delay in the teapot example because there is a lot of motion events)

By the way, why is the teapot example disabled by default ? It seems it always was like this (see https://github.com/wiiuse/wiiuse/blob/24b1063e59411948fb47e044cf97a6f2a93ee564/example-sdl/sdl.c) but when I tried it, the example seemed to work fine.

May I re-enable it ?
