### PR TITLE
add wiiuse_set_wii_board_calib

### DIFF
--- a/src/wiiboard.c
+++ b/src/wiiboard.c
@@ -163,7 +163,7 @@ void wii_board_event(struct wii_board_t *wb, byte *msg)
 /**
 *   @brief Calib wii board
 * 
-*    @param wm      Pointer to a wiimote_t structure the calib values of are used.
+*    @param wm      Pointer to a wiimote_t struct the calib values are used.
 */
 void wiiuse_set_wii_board_calib(struct wiimote_t *wm)
 {
@@ -178,17 +178,28 @@ void wiiuse_set_wii_board_calib(struct wiimote_t *wm)
     to_big_endian_uint32_t(pkt, WM_EXP_MEM_CALIBR + 4);
 
     pkt[0] = 0x04; //write register
+    pkt[4] = 0x0f; //size of data
+
+    to_big_endian_uint16_t(&pkt[5], wm->exp.wb.ctr[0]);
+    to_big_endian_uint16_t(&pkt[7], wm->exp.wb.cbr[0]);
+    to_big_endian_uint16_t(&pkt[9], wm->exp.wb.ctl[0]);
+    to_big_endian_uint16_t(&pkt[11], wm->exp.wb.cbl[0]);
+    to_big_endian_uint16_t(&pkt[13], wm->exp.wb.ctr[1]);
+    to_big_endian_uint16_t(&pkt[15], wm->exp.wb.cbr[1]);
+    to_big_endian_uint16_t(&pkt[17], wm->exp.wb.ctl[1]);
+    to_big_endian_uint16_t(&pkt[19], wm->exp.wb.cbl[1]);
+    if (wiiuse_send(wm, WM_CMD_WRITE_DATA, pkt, sizeof(pkt)) < 0)
+        return;
+    wiiuse_millisleep(100);
+
+    to_big_endian_uint32_t(pkt, WM_EXP_MEM_CALIBR + 20);
+    pkt[0] = 0x04; //write register
     pkt[4] = 0x08; //size of data
-    for (size_t i = 0; i < 3; i++)
-    {
-        to_big_endian_uint16_t(&pkt[5], wm->exp.wb.ctr[i]);
-        to_big_endian_uint16_t(&pkt[7], wm->exp.wb.cbr[i]);
-        to_big_endian_uint16_t(&pkt[9], wm->exp.wb.ctl[i]);
-        to_big_endian_uint16_t(&pkt[11], wm->exp.wb.cbl[i]);
-        if (wiiuse_send(wm, WM_CMD_WRITE_DATA, pkt, sizeof(pkt)) < 0)
-        {
-            return;
-        }
-        sleep(1);
-    }
+
+    to_big_endian_uint16_t(&pkt[5], wm->exp.wb.ctr[2]);
+    to_big_endian_uint16_t(&pkt[7], wm->exp.wb.cbr[2]);
+    to_big_endian_uint16_t(&pkt[9], wm->exp.wb.ctl[2]);
+    to_big_endian_uint16_t(&pkt[11], wm->exp.wb.cbl[2]);
+    wiiuse_send(wm, WM_CMD_WRITE_DATA, pkt, sizeof(pkt));
+    wiiuse_millisleep(100);
 }

--- a/src/wiiboard.c
+++ b/src/wiiboard.c
@@ -161,6 +161,34 @@ void wii_board_event(struct wii_board_t *wb, byte *msg)
 }
 
 /**
-        @todo not implemented!
+*   @brief Calib wii board
+* 
+*    @param wm      Pointer to a wiimote_t structure the calib values of are used.
 */
-void wiiuse_set_wii_board_calib(struct wiimote_t *wm) {}
+void wiiuse_set_wii_board_calib(struct wiimote_t *wm)
+{
+    byte pkt[21];
+    uint16_t test = 1;
+    memset(pkt, 0, sizeof(pkt));
+
+    /*
+     * address in big endian first, the leading byte will
+     * be overwritten (only 3 bytes are sent)
+     */
+    to_big_endian_uint32_t(pkt, WM_EXP_MEM_CALIBR + 4);
+
+    pkt[0] = 0x04; //write register
+    pkt[4] = 0x08; //size of data
+    for (size_t i = 0; i < 3; i++)
+    {
+        to_big_endian_uint16_t(&pkt[5], wm->exp.wb.ctr[i]);
+        to_big_endian_uint16_t(&pkt[7], wm->exp.wb.cbr[i]);
+        to_big_endian_uint16_t(&pkt[9], wm->exp.wb.ctl[i]);
+        to_big_endian_uint16_t(&pkt[11], wm->exp.wb.cbl[i]);
+        if (wiiuse_send(wm, WM_CMD_WRITE_DATA, pkt, sizeof(pkt)) < 0)
+        {
+            return;
+        }
+        sleep(1);
+    }
+}

--- a/src/wiiuse.h
+++ b/src/wiiuse.h
@@ -953,7 +953,6 @@ WIIUSE_EXPORT extern void wiiuse_set_nunchuk_orient_threshold(struct wiimote_t *
 WIIUSE_EXPORT extern void wiiuse_set_nunchuk_accel_threshold(struct wiimote_t *wm, int threshold);
 
 /* wiiboard.c */
-/* this function not currently implemented... */
 WIIUSE_EXPORT extern void wiiuse_set_wii_board_calib(struct wiimote_t *wm);
 
 WIIUSE_EXPORT extern void wiiuse_set_motion_plus(struct wiimote_t *wm, int status);


### PR DESCRIPTION
implement the wiiuse_set_wii_board_calib function.
the values currently set in the wii_board_t struct are stored in the board as new calibration.