### PR TITLE
Load libbluetooth at runtime on linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,7 +61,7 @@ add_library(wiiuse ${SOURCES} ${API})
 if(WIN32)
 	target_link_libraries(wiiuse ws2_32 setupapi ${WINHID_LIBRARIES})
 elseif(LINUX)
-	target_link_libraries(wiiuse m rt ${BLUEZ_LIBRARIES})
+	target_link_libraries(wiiuse m rt ${CMAKE_DL_LIBS})
 elseif(APPLE)
 	# link libraries
 	find_library(IOBLUETOOTH_FRAMEWORK

--- a/src/os_nix.c
+++ b/src/os_nix.c
@@ -69,7 +69,7 @@ static struct {
 
 static void load_bluez_symbols(void)
 {
-  void* bluetooth = dlopen("libbluetooth.so", RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
+  void* bluetooth = dlopen("libbluetooth.so.3", RTLD_LAZY | RTLD_LOCAL | RTLD_NODELETE);
   if(!bluetooth)
     return;
 


### PR DESCRIPTION
This PR moves the loading of libbluetooth.so from load-time to run-time on linux. I had to implement it because for the software in which I'm using wiiuse, https://ossia.io , it sometimes happened that users did not have libbluetooth on their linux machine, which caused the usual startup crash due to missing libraries