### PR TITLE
Correct misunderstanding of libogc code

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -257,12 +257,11 @@ greatly appreciated.
 
 ### Forks not yet fully integrated
 
-- [libogc/WPAD/DevKitPro](http://wiibrew.org/wiki/Libogc)
-  - Started before the disappearance of the original upstream
+- [libogc/wiiuse](https://github.com/devkitPro/libogc/tree/master/wiiuse)
+  - wii port created by Shagkur and contributed upstream
   - Focused on Wiimote use with Wii hardware
-  - Functions renamed, copyright statements removed
+  - code unfortunately diverged
   - Additional functionality unknown?
-  - git-svn mirror found here: <https://github.com/xloem/libogc-wiiuse>
 - [fwiine](http://sourceforge.net/projects/fwiine/files/wiiuse/0.13/)
   - Created an 0.13 version with some very preliminary MotionPlus support.
   - Integrated into branch `fwiine-motionplus`, not yet merged pending


### PR DESCRIPTION
There appears to be a misunderstanding of the wiiuse code in libogc. This corrects the record and links directly to our repository.

Shagkur ported lwbt and wiiuse for use directly on the Wii and that code was contributed upstream. While functions may have been renamed it is not true that copyright statements were removed. They were added when Shagkur's code was upstreamed. See https://web.archive.org/web/20080601015526/http://www.wiiuse.net/forums/viewtopic.php?t=197

There has been some divergence since unfortunately which may make it difficult to reintegrate. Personally I would prefer to remove wiiuse code from libogc & build a portlib from this upstream instead if it's possible but in the meantime I would like the record corrected. 