### PR TITLE
make wiiuse a shared library as the README suggests it should be

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 
 add_definitions(-DWIIUSE_COMPILE_LIB)
 
-add_library(wiiuse ${SOURCES} ${API})
+add_library(wiiuse SHARED ${SOURCES} ${API})
 
 if(WIN32)
 	target_link_libraries(wiiuse ws2_32 setupapi ${WINHID_LIBRARIES})


### PR DESCRIPTION
This changes the cmake such that `libwiiuse` outputs as `libwiiuse.so` rather than `libwiiuse.a` as the README suggests it should be.

Here is the output of `file` running on both the .a (generated by a previous build before this change) and the .so files generated as a result of this change:
![Screenshot_20231107_160416](https://github.com/wiiuse/wiiuse/assets/54519080/c1737aa0-d0b9-4cd3-b6e4-091ff5d272cd)
