### PR TITLE
improve MinGW build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ if(NOT SUBPROJECT)
 # Set packaging options (for CPack)
 ###
 
-	if(WIN32)
+	if(MSVC)
 		set(DOC_DIR .)
 	else()
 		set(DOC_DIR share/doc/wiiuse)


### PR DESCRIPTION
MinGW toolchain also can work with .pc files. a MinGW-w64 distributions such as MSYS2 also use `shere/doc` path for documentation