### PR TITLE
wiiuse.pc.in: allow absolute paths of `CMAKE_INSTALL_LIBDIR`

### DIFF
--- a/wiiuse.pc.in
+++ b/wiiuse.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: WiiUse
 Description: @PROJECT_DESCRIPTION@


### PR DESCRIPTION
Without the change `wiiuse.pc.in` generated double install-prefix on systems that uise absolute paths for `CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_INSTALLDIR`. An example system is `nixpkgs`.

https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html#result-variables