### PR TITLE
Add Tatacon support

### DIFF
--- a/example/example.c
+++ b/example/example.c
@@ -292,6 +292,21 @@ void handle_event(struct wiimote_t* wm) {
 		printf("Weight: %f kg @ (%f, %f)\n", total, x, y);
 		printf("Interpolated weight: TL:%f  TR:%f  BL:%f  BR:%f\n", wb->tl, wb->tr, wb->bl, wb->br);
 		printf("Raw: TL:%d  TR:%d  BL:%d  BR:%d\n", wb->rtl, wb->rtr, wb->rbl, wb->rbr); 
+	} else if (wm->exp.type == EXP_TATACON) {
+		/* tatacon */
+		struct tatacon_t* tatacon = (tatacon_t*)&wm->exp.tatacon;
+		if (IS_PRESSED(tatacon, TATACON_BUTTON_RIM_LEFT)) {
+			printf("Tatacon: Left Rim Hit\n");
+		}
+		if (IS_PRESSED(tatacon, TATACON_BUTTON_CENTER_LEFT)) {
+			printf("Tatacon: Left Center Hit\n");
+		}
+		if (IS_PRESSED(tatacon, TATACON_BUTTON_CENTER_RIGHT)) {
+			printf("Tatacon: Right Center Hit\n");
+		}
+		if (IS_PRESSED(tatacon, TATACON_BUTTON_RIM_RIGHT)) {
+			printf("Tatacon: Right Rim Hit\n");
+		}
 	}
 
 	if (wm->exp.type == EXP_MOTION_PLUS ||
@@ -557,11 +572,18 @@ int main(int argc, char** argv) {
 						printf("Guitar Hero 3 controller inserted.\n");
 						break;
 
+					case WIIUSE_TATACON_CTRL_INSERTED:
+						/* some expansion was inserted */
+						handle_ctrl_status(wiimotes[i]);
+						printf("Tatacon controller inserted.\n");
+						break;
+
 					case WIIUSE_MOTION_PLUS_ACTIVATED:
 						printf("Motion+ was activated\n");
 						break;
 
 					case WIIUSE_NUNCHUK_REMOVED:
+					case WIIUSE_TATACON_CTRL_REMOVED:
 					case WIIUSE_CLASSIC_CTRL_REMOVED:
 					case WIIUSE_GUITAR_HERO_3_CTRL_REMOVED:
 					case WIIUSE_WII_BOARD_CTRL_REMOVED:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,8 @@ set(SOURCES
 	ir.h
 	nunchuk.h
 	os.h
+	tatacon.c
+	tatacon.h
 	util.c
 	wiiuse_internal.h
 	wiiboard.h)

--- a/src/events.c
+++ b/src/events.c
@@ -45,6 +45,7 @@
 #include "motion_plus.h"   /* for motion_plus_disconnected, etc */
 #include "nunchuk.h"       /* for nunchuk_disconnected, etc */
 #include "wiiboard.h"      /* for wii_board_disconnected, etc */
+#include "tatacon.h"       /* for tatacon_disconnected, etc */
 
 #include "os.h" /* for wiiuse_os_poll */
 
@@ -674,6 +675,9 @@ static void handle_expansion(struct wiimote_t *wm, byte *msg)
     case EXP_MOTION_PLUS_NUNCHUK:
         motion_plus_event(&wm->exp.mp, wm->exp.type, msg);
         break;
+    case EXP_TATACON:
+        tatacon_event(&wm->exp.tatacon, msg);
+        break;
     default:
         break;
     }
@@ -809,6 +813,12 @@ void handshake_expansion(struct wiimote_t *wm, byte *data, uint16_t len)
             gotIt     = 1;
         }
         break;
+    
+    case EXP_ID_CODE_TATACON:
+        tatacon_handshake(wm, &wm->exp.tatacon, handshake_buf, EXP_HANDSHAKE_LEN);
+        wm->event = WIIUSE_TATACON_CTRL_INSERTED;
+        gotIt = 1;
+        break;
 
     default:
         WIIUSE_WARNING("Unknown expansion type. Code: 0x%x", id);
@@ -872,6 +882,10 @@ void disable_expansion(struct wiimote_t *wm)
     case EXP_MOTION_PLUS_NUNCHUK:
         motion_plus_disconnected(&wm->exp.mp);
         wm->event = WIIUSE_MOTION_PLUS_REMOVED;
+        break;
+    case EXP_TATACON:
+        tatacon_disconnected(&wm->exp.tatacon);
+        wm->event = WIIUSE_TATACON_CTRL_REMOVED;
         break;
     default:
         break;
@@ -961,6 +975,10 @@ static void save_state(struct wiimote_t *wm)
 
         break;
     }
+
+    case EXP_TATACON:
+        wm->lstate.exp_btns = wm->exp.tatacon.btns;
+        break;
 
     case EXP_NONE:
         break;
@@ -1110,6 +1128,10 @@ static int state_changed(struct wiimote_t *wm)
 
         break;
     }
+    case EXP_TATACON:
+        STATE_CHANGED(wm->lstate.exp_btns, wm->exp.tatacon.btns);
+        break;
+
     case EXP_NONE:
     {
         break;

--- a/src/tatacon.c
+++ b/src/tatacon.c
@@ -1,0 +1,105 @@
+/*
+ *	wiiuse
+ *
+ *	Written By:
+ *		pixelomer
+ *
+ *	Copyright 2026
+ *
+ *	Adapted from nunchuk.c
+ *
+ *	Written By:
+ *		Michael Laforest	< para >
+ *		Email: < thepara (--AT--) g m a i l [--DOT--] com >
+ *
+ *	Copyright 2006-2007
+ *
+ *	This file is part of wiiuse.
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	$Header$
+ *
+ */
+
+/**
+ *	@file
+ *	@brief tatacon expansion device.
+ */
+
+#include "tatacon.h"
+#include "events.h"   /* for handshake_expansion */
+
+#include <stdlib.h> /* for malloc */
+#include <string.h> /* for memset */
+
+/**
+ *	@brief Handle the handshake data from the tatacon.
+ *
+ *	@param tatacon	A pointer to a tatacon_t structure.
+ *	@param data		The data read in from the device.
+ *	@param len		The length of the data block, in bytes.
+ *
+ *	@return	Returns 1 if handshake was successful, 0 if not.
+ */
+#define HANDSHAKE_BYTES_USED 14
+int tatacon_handshake(struct wiimote_t *wm, struct tatacon_t *tatacon, byte *data, unsigned short len)
+{
+    tatacon->btns          = 0;
+
+    /* handshake done (nothing to do) */
+    wm->exp.type = EXP_TATACON;
+
+#ifdef WIIUSE_WIN32
+    wm->timeout = WIIMOTE_DEFAULT_TIMEOUT;
+#endif
+
+    return 1;
+}
+
+/**
+ *	@brief The tatacon disconnected.
+ *
+ *	@param tatacon	A pointer to a tatacon_t structure.
+ */
+void tatacon_disconnected(struct tatacon_t *tatacon) {
+    memset(tatacon, 0, sizeof(struct tatacon_t));
+}
+
+/**
+ *	@brief Handle tatacon event.
+ *
+ *	@param tatacon	A pointer to a tatacon_t structure.
+ *	@param msg		The message specified in the event packet.
+ */
+void tatacon_event(struct tatacon_t *tatacon, byte *msg)
+{
+    /* get button states */
+    tatacon_pressed_buttons(tatacon, msg[5]);
+}
+
+/**
+ *	@brief Find what buttons are pressed.
+ *
+ *	@param tatacon	Pointer to a tatacon_t structure.
+ *	@param now		The buttons byte in the event packet.
+ */
+void tatacon_pressed_buttons(struct tatacon_t *tatacon, byte now)
+{
+    /* message is inverted (0 is active, 1 is inactive) */
+    now = ~now & TATACON_BUTTON_ALL;
+
+    /* buttons pressed now */
+    tatacon->btns = now;
+}

--- a/src/tatacon.h
+++ b/src/tatacon.h
@@ -1,0 +1,65 @@
+/*
+ *	wiiuse
+ *
+ *	Written By:
+ *		pixelomer
+ *
+ *	Copyright 2026
+ *
+ *	Adapted from nunchuk.h
+ * 
+ *	Written By:
+ *		Michael Laforest	< para >
+ *		Email: < thepara (--AT--) g m a i l [--DOT--] com >
+ *
+ *	Copyright 2006-2007
+ *
+ *	This file is part of wiiuse.
+ *
+ *	This program is free software; you can redistribute it and/or modify
+ *	it under the terms of the GNU General Public License as published by
+ *	the Free Software Foundation; either version 3 of the License, or
+ *	(at your option) any later version.
+ *
+ *	This program is distributed in the hope that it will be useful,
+ *	but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *	GNU General Public License for more details.
+ *
+ *	You should have received a copy of the GNU General Public License
+ *	along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *	$Header$
+ *
+ */
+
+/**
+ *	@file
+ *	@brief Tatacon expansion device.
+ */
+
+#ifndef TATACON_H_INCLUDED
+#define TATACON_H_INCLUDED
+
+#include "wiiuse_internal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @defgroup internal_tatacon Internal: Tatacon */
+/** @{ */
+int tatacon_handshake(struct wiimote_t *wm, struct tatacon_t *tatacon, byte *data, unsigned short len);
+
+void tatacon_disconnected(struct tatacon_t *tatacon);
+
+void tatacon_event(struct tatacon_t *tatacon, byte *msg);
+
+void tatacon_pressed_buttons(struct tatacon_t *tatacon, byte now);
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TATACON_H_INCLUDED */

--- a/src/wiiuse.h
+++ b/src/wiiuse.h
@@ -220,6 +220,15 @@
 #define GUITAR_HERO_3_BUTTON_ALL        0xFEFF
 /** @} */
 
+/** @name Tatacon button codes */
+/** @{ */
+#define TATACON_BUTTON_CENTER_LEFT      0x40
+#define TATACON_BUTTON_CENTER_RIGHT     0x10
+#define TATACON_BUTTON_RIM_LEFT         0x20
+#define TATACON_BUTTON_RIM_RIGHT        0x08
+#define TATACON_BUTTON_ALL              0x78
+/** @} */
+
 /** @name Wiimote option flags */
 /** @{ */
 #define WIIUSE_SMOOTHING     0x01
@@ -240,6 +249,7 @@
 #define EXP_MOTION_PLUS 5
 #define EXP_MOTION_PLUS_NUNCHUK 6 /* Motion+ in nunchuk pass-through mode */
 #define EXP_MOTION_PLUS_CLASSIC 7 /* Motion+ in classic ctr. pass-through mode */
+#define EXP_TATACON 8
 /** @} */
 
 /** @brief IR correction types */
@@ -589,6 +599,14 @@ typedef struct motion_plus_t
 } motion_plus_t;
 
 /**
+ *	@brief Tatacon expansion device.
+ */
+typedef struct tatacon_t
+{
+    int8_t btns;          /**< what buttons have just been pressed	*/
+} tatacon_t;
+
+/**
  *	@brief Wii Balance Board "expansion" device.
  *
  *  A Balance Board presents itself as a Wiimote with a permanently-attached
@@ -644,6 +662,7 @@ typedef struct expansion_t
         struct classic_ctrl_t classic;
         struct guitar_hero_3_t gh3;
         struct wii_board_t wb;
+        struct tatacon_t tatacon;
     };
 } expansion_t;
 
@@ -711,7 +730,9 @@ typedef enum WIIUSE_EVENT_TYPE {
     WIIUSE_WII_BOARD_CTRL_INSERTED,
     WIIUSE_WII_BOARD_CTRL_REMOVED,
     WIIUSE_MOTION_PLUS_ACTIVATED,
-    WIIUSE_MOTION_PLUS_REMOVED
+    WIIUSE_MOTION_PLUS_REMOVED,
+    WIIUSE_TATACON_CTRL_INSERTED,
+    WIIUSE_TATACON_CTRL_REMOVED
 } WIIUSE_EVENT_TYPE;
 
 /**

--- a/src/wiiuse_internal.h
+++ b/src/wiiuse_internal.h
@@ -224,6 +224,7 @@
 #define EXP_ID_CODE_MOTION_PLUS         0xA4200405
 #define EXP_ID_CODE_MOTION_PLUS_NUNCHUK 0xA4200505 /** Motion Plus ID in Nunchuck passthrough mode */
 #define EXP_ID_CODE_MOTION_PLUS_CLASSIC 0xA4200705 /** Motion Plus ID in Classic control. passthrough */
+#define EXP_ID_CODE_TATACON             0xA4200111
 
 /* decrypted M+ codes at 0x04A600FA */
 #define EXP_ID_CODE_INACTIVE_MOTION_PLUS         0xA6200005         /** Inactive Motion Plus ID */


### PR DESCRIPTION
Based on https://wiibrew.org/wiki/Wiimote/Extension_Controllers/TaTaCon. Tested with an original Wii Tatacon.