### PR TITLE
example-sdl: fix a year-2038-problem

### DIFF
--- a/example-sdl/sdl.c
+++ b/example-sdl/sdl.c
@@ -68,7 +68,7 @@ int ycoord = 0;
 DWORD last_render;
 #else
 struct timeval last_render;
-int last_sec = 0;
+time_t last_sec = 0;
 int fps = 0;
 #endif
 


### PR DESCRIPTION
We use `time_t` instead of `int`.

See https://en.wikipedia.org/wiki/Year_2038_problem

This patch was done while reviewing potential year-2038 issues in openSUSE.